### PR TITLE
Moves app.use catchall to a line below the app.use(router)

### DIFF
--- a/server.js
+++ b/server.js
@@ -14,12 +14,6 @@ if (process.env.NODE_ENV === "production") {
   app.use(express.static("client/build"));
 }
 
-// Send every request to the React app
-// Define any API routes before this runs
-app.get("*", function(req, res) {
-  res.sendFile(path.join(__dirname, "./client/build/index.html"));
-});
-
 app.use(bodyParser.urlencoded({ extended: true}));
 app.use(bodyParser.json());
 app.use(cors());
@@ -45,6 +39,12 @@ db.Charity.find({})
 	})
 
 app.use(router)
+
+// Send every request to the React app
+// Define any API routes before this runs
+app.get("*", function(req, res) {
+  res.sendFile(path.join(__dirname, "./client/build/index.html"));
+});
 
 app.listen(PORT, function() {
   console.log(`🌎 ==> Server now on port ${PORT}!`);


### PR DESCRIPTION
Hey @sandond77,
You had a line with `app.use('*', ...` near the top of your server.js file.  I moved it to below the app.use(router) on line 41.  This way the code will use your router defined routes first before it sends all traffic to your react app.